### PR TITLE
ignore all build error files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -357,3 +357,4 @@ NuGet.config
 
 # MacOS files
 .DS_Store
+**/.trydotnet-builderror


### PR DESCRIPTION
The .trydotnet-builderror files should not be in source control.
