### PR TITLE
Add necessary files for samples browser indexing.

### DIFF
--- a/101-linq-samples/readme.md
+++ b/101-linq-samples/readme.md
@@ -21,6 +21,6 @@ Learn how to use LINQ in your applications with these code samples, covering the
 
 To run these samples, you'll need to follow the instructions on hte [dotnet/try-samples](https://github.com/dotnet/try-samples#basics) repository to install the global `dotnet try` tool in your .NET environment. 
 
-Once you've installed the global tool, running `dotnet try` loads the samples into a browser. The browser pages introduce important concepts in LINQ, and you an run teh code interactively in your browser.
+Once you've installed the global tool, running `dotnet try` loads the samples into a browser. The browser pages introduce important concepts in LINQ, and you run the code interactively in your browser.
 
 If you loaded this page from `dotnet try`, click [here](index.md) to start the sample. (This link will not work in the samples browser).

--- a/Beginners/Readme.md
+++ b/Beginners/Readme.md
@@ -1,13 +1,26 @@
-#  Try .NET Enabled Samples
-![dotnet try Enabled](https://img.shields.io/badge/Try_.NET-Enabled-501078.svg)
+---
+name: "Learn programming using C# and Try.NET"
+description: "Explore the C# language, .NET, programming concepts. Learn to program interactively using the try.net interactive experience."
+page_type: sample
+languages:
+  - csharp
+products:
+  - dotnet-core
+---
 
-*Please read the [Try .NET quick setup guide](Setup.md) before starting the tutorial below.* 
+# Learn programming with TRY.NET
+![dotnet try Enabled](https://img.shields.io/badge/Try_.NET-Enabled-501078.svg)
 
 <p align ="center">
 <img src ="https://user-images.githubusercontent.com/2546640/56708992-deee8780-66ec-11e9-9991-eb85abb1d10a.png" width="350">
 </p>
-<h1 align ="center">Try .NET Samples</h1>
 
-### Table of Content 
-- [Introduction Programming with C#](HelloWorld.md)
-- [Pascals Triangle](TeachTheComputer.md)
+These explorations show you the structure of C# programs, working with text, numbers, and other core data structures.
+
+## Learn to program using this tutorial
+
+To run these samples, you'll need to follow the instructions on hte [dotnet/try-samples](https://github.com/dotnet/try-samples#basics) repository to install the global `dotnet try` tool in your .NET environment.
+
+Once you've installed the global tool, running `dotnet try` loads the samples into a browser. The browser pages introduce important programming concepts through interactive exercises you run in your browser.
+
+If you loaded this page from `dotnet try`, click [here](index.md) to start the sample. (This link will not work in the samples browser).

--- a/Beginners/index.md
+++ b/Beginners/index.md
@@ -1,0 +1,12 @@
+#  Try .NET Enabled Samples
+![dotnet try Enabled](https://img.shields.io/badge/Try_.NET-Enabled-501078.svg)
+
+*Please read the [Try .NET quick setup guide](Setup.md) before starting the tutorial below.* 
+
+<p align ="center">
+<img src ="https://user-images.githubusercontent.com/2546640/56708992-deee8780-66ec-11e9-9991-eb85abb1d10a.png" width="350">
+</p>
+
+### Table of Content 
+- [Introduction Programming with C#](HelloWorld.md)
+- [Pascals Triangle](TeachTheComputer.md)

--- a/csharp7/index.md
+++ b/csharp7/index.md
@@ -1,0 +1,62 @@
+# What's new in C# 7.0 thru C# 7.3 - exploration
+
+![dotnet try Enabled](https://img.shields.io/badge/Try_.NET-Enabled-501078.svg)
+
+<p align ="center">
+<img src ="https://user-images.githubusercontent.com/2546640/56708992-deee8780-66ec-11e9-9991-eb85abb1d10a.png" width="350">
+</p>
+
+The themes of these releases are:
+
+## Better control over allocations and copies
+
+The .NET environment manages memory automatically. However, some scenarios require developers to take more control over the memory footprint of their application. This has meant developers needed to write unsafe code. The goal of these features is to enable developers to achieve the performance of unsafe code while writing verifiably safe code. The features that enable these gains are:
+
+- [ref locals and returns](./ref-locals-returns.md)
+- [in and ref readonly](./in-ref-readonly.md)
+- [readonly struct](./readonly-struct.md)
+- [ref struct](./readonly-struct#ref-struct-types.md)
+
+## Pattern matching
+
+Modern applications are often a collection of different programs that execute on multiple machines and platforms. That separates data from the code that consumes the data. A strict object oriented approach doesn't work as well in these systems. **Pattern matching** enables new ways to examine data using its type, shape, or values. The features added for pattern matching are:
+
+- [pattern matching is expressions](./is-expressions.md)
+- [pattern matching with switch](./switch-patterns.md)
+- [pattern matching on generic type elements](./generic-patterns.md)
+
+## Tuple data types
+
+Tuples combine both of the previous themes: They are lightweight value types that contain multiple members:
+
+- [Create lightweight data structures using tuples](./declare-tuples.md)
+
+## Preparing for nullable reference types
+
+Features were added to C# 7.x that make it easier to adopt nullable reference types in C# 8. These features reduce the locations where you must declare a variable and initialize it later.
+
+- [Declare out variables when assigned](./out-variable-declaration.md)
+
+Many of these use unsafe code, which aren't available in the local `dotnet try` environment. Learn more about them on docs.microsoft.com:
+
+- [fixed fields without pinning](https://docs.microsoft.com/dotnet/csharp/whats-new/csharp-7-3)
+- [stackalloc array initializers](https://docs.microsoft.com/dotnet/csharp/whats-new/csharp-7-3#stackalloc-arrays-support-initializers)
+- [Conditional ref expressions](https://docs.microsoft.com/dotnet/csharp/whats-new/csharp-7-2#conditional-ref-expressions)
+
+## Improve code organization and readability
+
+Other features improve your ability to write clear code in a variety of scenarios:
+
+- [local functions](local-functions.md)
+- [new generic constraints ](generic-constraints.md)
+
+Two other features aren't in this tutorial. Learn more about them on docs.microsoft.com:
+
+- [attributes on backing fields of properties](https://docs.microsoft.com/dotnet/csharp/whats-new/csharp-7-3#attach-attributes-to-the-backing-fields-for-auto-implemented-properties)
+- [Async Main methods](https://docs.microsoft.com/dotnet/csharp/whats-new/csharp-7-1#async-main)
+- [default literal expressions](https://docs.microsoft.com/dotnet/csharp/whats-new/csharp-7-1#default-literal-expressions)
+- [Leading underscores in numeric literals](https://docs.microsoft.com/dotnet/csharp/whats-new/csharp-7-2#leading-underscores-in-numeric-literals)
+
+You can try these scenarios and features in C# 7.x by stepping through the different sections of this tutorial. Or, you can select any of the preceding links to go to the feature you want to explore first.
+
+## Next: [ref locals and returns &raquo;](./ref-locals-returns.md)

--- a/csharp7/readme.md
+++ b/csharp7/readme.md
@@ -1,58 +1,26 @@
+---
+name: "Explore C# 7.0 - 7.3"
+description: "Explore the new features in the C# language released in versions 7.0 - 7.3. Learn to program interactively using the try.net interactive experience with .NET Core."
+page_type: sample
+languages:
+  - csharp
+products:
+  - dotnet-core
+---
 # What's new in C# 7.0 thru C# 7.3 - exploration
+
+![dotnet try Enabled](https://img.shields.io/badge/Try_.NET-Enabled-501078.svg)
+
+<p align ="center">
+<img src ="https://user-images.githubusercontent.com/2546640/56708992-deee8780-66ec-11e9-9991-eb85abb1d10a.png" width="350">
+</p>
 
 This exploration enables you to experiment with the features that have been released in C# 7.0, and the following point releases through C# 7.3. You can try the code in the samples, modify it, and see the effects of using the new features in a variety of scenarios. Some of the features added in the point releases are enhancements and improvements to features first available in C# 7.0. This exploration is organized around the themes across all the C# 7.x features, rather than by release. As you explore each area, enhancements that are available in later point releases are noted.
 
-The themes of these releases are:
+## What's new in C# 7.0 thru C# 7.3 - exploration
 
-## Better control over allocations and copies
+To run these samples, you'll need to follow the instructions on hte [dotnet/try-samples](https://github.com/dotnet/try-samples#basics) repository to install the global `dotnet try` tool in your .NET environment.
 
-The .NET environment manages memory automatically. However, some scenarios require developers to take more control over the memory footprint of their application. This has meant developers needed to write unsafe code. The goal of these features is to enable developers to achieve the performance of unsafe code while writing verifiably safe code. The features that enable these gains are:
+Once you've installed the global tool, running `dotnet try` loads the samples into a browser. The browser pages introduce important programming concepts through interactive exercises you run in your browser.
 
-- [ref locals and returns](./ref-locals-returns.md)
-- [in and ref readonly](./in-ref-readonly.md)
-- [readonly struct](./readonly-struct.md)
-- [ref struct](./readonly-struct#ref-struct-types.md)
-
-## Pattern matching
-
-Modern applications are often a collection of different programs that execute on multiple machines and platforms. That separates data from the code that consumes the data. A strict object oriented approach doesn't work as well in these systems. **Pattern matching** enables new ways to examine data using its type, shape, or values. The features added for pattern matching are:
-
-- [pattern matching is expressions](./is-expressions.md)
-- [pattern matching with switch](./switch-patterns.md)
-- [pattern matching on generic type elements](./generic-patterns.md)
-
-## Tuple data types
-
-Tuples combine both of the previous themes: They are lightweight value types that contain multiple members:
-
-- [Create lightweight data structures using tuples](./declare-tuples.md)
-
-## Preparing for nullable reference types
-
-Features were added to C# 7.x that make it easier to adopt nullable reference types in C# 8. These features reduce the locations where you must declare a variable and initialize it later.
-
-- [Declare out variables when assigned](./out-variable-declaration.md)
-
-Many of these use unsafe code, which aren't available in the local `dotnet try` environment. Learn more about them on docs.microsoft.com:
-
-- [fixed fields without pinning](https://docs.microsoft.com/dotnet/csharp/whats-new/csharp-7-3)
-- [stackalloc array initializers](https://docs.microsoft.com/dotnet/csharp/whats-new/csharp-7-3#stackalloc-arrays-support-initializers)
-- [Conditional ref expressions](https://docs.microsoft.com/dotnet/csharp/whats-new/csharp-7-2#conditional-ref-expressions)
-
-## Improve code organization and readability
-
-Other features improve your ability to write clear code in a variety of scenarios:
-
-- [local functions](local-functions.md)
-- [new generic constraints ](generic-constraints.md)
-
-Two other features aren't in this tutorial. Learn more about them on docs.microsoft.com:
-
-- [attributes on backing fields of properties](https://docs.microsoft.com/dotnet/csharp/whats-new/csharp-7-3#attach-attributes-to-the-backing-fields-for-auto-implemented-properties)
-- [Async Main methods](https://docs.microsoft.com/dotnet/csharp/whats-new/csharp-7-1#async-main)
-- [default literal expressions](https://docs.microsoft.com/dotnet/csharp/whats-new/csharp-7-1#default-literal-expressions)
-- [Leading underscores in numeric literals](https://docs.microsoft.com/dotnet/csharp/whats-new/csharp-7-2#leading-underscores-in-numeric-literals)
-
-You can try these scenarios and features in C# 7.x by stepping through the different sections of this tutorial. Or, you can select any of the preceding links to go to the feature you want to explore first.
-
-## Next: [ref locals and returns &raquo;](./ref-locals-returns.md)
+If you loaded this page from `dotnet try`, click [here](index.md) to start the sample. (This link will not work in the samples browser).

--- a/csharp8/index.md
+++ b/csharp8/index.md
@@ -1,0 +1,29 @@
+# What's new in C# 8.0 - exploration
+
+
+![dotnet try Enabled](https://img.shields.io/badge/Try_.NET-Enabled-501078.svg)
+
+<p align ="center">
+<img src ="https://user-images.githubusercontent.com/2546640/56708992-deee8780-66ec-11e9-9991-eb85abb1d10a.png" width="350">
+</p>
+
+This exploration enables you to experiment with the features that have been released in C# 8.0, preview 2. You can try the code in the samples, modify it, and see the effects of using the new features in a variety of scenarios.
+
+You can try the following features that first appeared in preview 2:
+
+- [Pattern matching enhancements](./patterns.md):
+- [Static local functions](static-local-functions.md)
+- [Using declarations](using-declarations-ref-structs.md)
+
+The following language features first appeared in C# 8.0 preview 1:
+
+- [Nullable reference types](nullable-reference-types.md)
+- [Asynchronous streams](asynchronous-streams.md)
+- [Indices and ranges](indices-and-ranges.md)
+
+> *Note*:
+> This exploration was last updated for C# 8.0 preview 2.
+
+You can try all of the features in the upcoming version of C# by stepping through the different sections of this tutorial. Or, you can select any of the preceding links to go to the feature you want to explore first.
+
+#### Next: [More patterns in more places &raquo;](./patterns.md)

--- a/csharp8/readme.md
+++ b/csharp8/readme.md
@@ -1,22 +1,26 @@
+---
+name: "Explore C# 8.0"
+description: "Explore the new features in the C# language released in version 8.0. Learn to program interactively using the try.net interactive experience with .NET Core."
+page_type: sample
+languages:
+  - csharp
+products:
+  - dotnet-core
+---
 # What's new in C# 8.0 - exploration
 
-This exploration enables you to experiment with the features that have been released in C# 8.0, preview 2. You can try the code in the samples, modify it, and see the effects of using the new features in a variety of scenarios.
+![dotnet try Enabled](https://img.shields.io/badge/Try_.NET-Enabled-501078.svg)
 
-You can try the following features that first appeared in preview 2:
+<p align ="center">
+<img src ="https://user-images.githubusercontent.com/2546640/56708992-deee8780-66ec-11e9-9991-eb85abb1d10a.png" width="350">
+</p>
 
-- [Pattern matching enhancements](./patterns.md):
-- [Static local functions](static-local-functions.md)
-- [Using declarations](using-declarations-ref-structs.md)
+This exploration enables you to experiment with the features that have been released in C# 8.0. You can try the code in the samples, modify it, and see the effects of using the new features in a variety of scenarios.
 
-The following language features first appeared in C# 8.0 preview 1:
+## What's new in C# 8.0 - exploration
 
-- [Nullable reference types](nullable-reference-types.md)
-- [Asynchronous streams](asynchronous-streams.md)
-- [Indices and ranges](indices-and-ranges.md)
+To run these samples, you'll need to follow the instructions on hte [dotnet/try-samples](https://github.com/dotnet/try-samples#basics) repository to install the global `dotnet try` tool in your .NET environment.
 
-> *Note*:
-> This exploration was last updated for C# 8.0 preview 2.
+Once you've installed the global tool, running `dotnet try` loads the samples into a browser. The browser pages introduce important programming concepts through interactive exercises you run in your browser.
 
-You can try all of the features in the upcoming version of C# by stepping through the different sections of this tutorial. Or, you can select any of the preceding links to go to the feature you want to explore first.
-
-#### Next: [More patterns in more places &raquo;](./patterns.md)
+If you loaded this page from `dotnet try`, click [here](index.md) to start the sample. (This link will not work in the samples browser).


### PR DESCRIPTION
This will add the remaining try.net tutorials to the docs.microsoft.com samples browser.

After this PR is merged, readers can find links to these samples at https://docs.microsoft.com/samples
