### PR TITLE
Change method name to match example code

### DIFF
--- a/101-linq-samples/docs/sequence-operations.md
+++ b/101-linq-samples/docs/sequence-operations.md
@@ -1,6 +1,6 @@
 # LINQ - Sequence operations
 
-These operators compare or manipulate entire sequences: `EqualAll`, `Concat`, and `Combine`.
+These operators compare or manipulate entire sequences: `SequenceEqual`, `Concat`, and `Combine`.
 
 ## Compare two sequences for equality
 


### PR DESCRIPTION
In example code does not use 'EqualAll' method. Therefore, I suggest to change method name to 'SequenceEqual'.
I was confused when I saw 'SequenceEqual' method because I expected to see 'EqualAll' method.