### PR TITLE
Fix the error regarding except-syntax.

### DIFF
--- a/101-linq-samples/src/Program.cs
+++ b/101-linq-samples/src/Program.cs
@@ -94,6 +94,7 @@ namespace Try101LinqSamples
                 "intersect-different-queries"   => new SetOperations().IntersectQueryResults(),
                 "difference-of-sets"            => new SetOperations().DifferenceOfSets(),
                 "difference-of-queries"         => new SetOperations().DifferenceOfQueries(),
+                "except-syntax"                 => new SetOperations().DifferenceOfSets(),
 
                 "convert-to-array"              => new Conversions().ConvertToArray(),
                 "convert-to-list"               => new Conversions().ConvertToList(),


### PR DESCRIPTION
There is no configuration for "except-syntax" so when running the code sample **Difference of two sets** on `101-linq-samples/docs/sets-2.md` it will throw an error. Thanks.