### PR TITLE
Fix broken link

### DIFF
--- a/csharp7/index.md
+++ b/csharp7/index.md
@@ -15,7 +15,7 @@ The .NET environment manages memory automatically. However, some scenarios requi
 - [ref locals and returns](./ref-locals-returns.md)
 - [in and ref readonly](./in-ref-readonly.md)
 - [readonly struct](./readonly-struct.md)
-- [ref struct](./readonly-struct#ref-struct-types.md)
+- [ref struct](./readonly-struct.md#ref-struct-types)
 
 ## Pattern matching
 


### PR DESCRIPTION
The link had the md extension on the fragment and not the file path. closes #66 