### PR TITLE
Take changed to Skip

### DIFF
--- a/101-linq-samples/docs/partitions.md
+++ b/101-linq-samples/docs/partitions.md
@@ -25,7 +25,7 @@ This sample uses `Skip` to get all but the first 4 elements of the array.
 
 ## Nested skip partitions
 
-This sample uses `Take` to get all but the first 2 orders from customers in Washington.
+This sample uses `Skip` to get all but the first 2 orders from customers in Washington.
 
 ``` cs --region nested-skip --source-file ../src/Partitions.cs --project ../src/Try101LinqSamples.csproj
 ```


### PR DESCRIPTION
In the last example, Skip is used but the doc says Take. Changed that